### PR TITLE
avoid clashing with local babel config file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export async function removeTypes(code: string, prettierConfig: PrettierOptions 
       retainLines: true,
       shouldPrintComment: (comment) => comment !== '___REMOVE_ME___',
     },
+    configFile: false,
   });
 
   if (!transformed || !transformed.code) {


### PR DESCRIPTION
Seeing as you're calling `transformAsync()` with all the config that you want it's probably a good idea to pass `configFile: false` to prevent any interactions with local babel configs 👍  