### PR TITLE
add a prepare script to be able to consume github urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "yarn clean && yarn ts:all",
     "clean": "rimraf ./*.d.ts ./*.d.ts.map ./dist",
     "lint": "eslint src test",
+    "prepare": "yarn build",
     "prepublishOnly": "yarn test && yarn build",
     "postpublish": "yarn clean",
     "release": "release-it",


### PR DESCRIPTION
When I was testing https://github.com/cafreeman/remove-types/pull/3 with a pnpm override it wouldn't run the build script because it relies on there being a prepare script to do that for you.

This PR adds that prepare script 👍 